### PR TITLE
Fixes typescript definition

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,24 +1,24 @@
 declare module 'koa2-swagger-ui' {
-  import { Middleware } from 'koa';
-  export function koaSwagger(config: swaggerUiConfig): any;
-
-  export interface swaggerUiConfig {
+  function koaSwagger(config: SwaggerUiConfig): import('koa').Middleware;
+  export interface SwaggerUiConfig {
     title?: string;
     oauthOptions?: boolean | any;
     swaggerOptions: {
-      dom_id?: string,
-      url: string,
-      supportedSubmitMethods?: string[],
-      docExpansion?: string,
-      jsonEditor?: boolean,
-      defaultModelRendering?: string,
-      showRequestHeaders?: boolean,
-      swaggerVersion?: string,
-      layout?: string,
+      dom_id?: string;
+      url: string;
+      supportedSubmitMethods?: string[];
+      docExpansion?: string;
+      jsonEditor?: boolean;
+      defaultModelRendering?: string;
+      showRequestHeaders?: boolean;
+      swaggerVersion?: string;
+      layout?: string;
     };
-    routePrefix: string;
+    routePrefix: string | false;
     hideTopbar?: boolean;
     favicon16?: string;
     favicon32?: string;
   }
+  export = koaSwagger
 }
+


### PR DESCRIPTION
Hi,

The new typescript definitions lead to compile errors in my Typescript based koa project.
This pull request fixes these errors and makes the following changes:

- koaSwagger will now be exported as (commonjs) default export
- sets the return type of koaSwagger to koa.Middleware
- routePrefix can now be false
- fix syntax errors (property definitions must be terminated by a ';')