### PR TITLE
feat: Support swagger-ui `spec` option

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,7 +15,8 @@ export interface SwaggerOptions {
   defaultModelRendering: string;
   showRequestHeaders: boolean;
   layout: string;
-  [key: string]: string | boolean | string[];
+  spec: object;
+  [key: string]: string | boolean | string[] | object;
 }
 
 export interface KoaSwaggerUiOptions {


### PR DESCRIPTION
`spec` allows passing OpenAPI definition as JS object (takes precedence over `url` option).

https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/