### PR TITLE
fix: swagger bundle url

### DIFF
--- a/lib/index.hbs
+++ b/lib/index.hbs
@@ -66,7 +66,7 @@
 
 <div id="swagger-ui"></div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/{{swaggerVersion}}/swagger-ui-bundle.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/{{swaggerVersion}}/swagger-ui-bundle.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/{{swaggerVersion}}/swagger-ui-standalone-preset.js"></script>
 <script>
 function HideTopbarPlugin() {


### PR DESCRIPTION
Javascript `swagger-ui-bundle.min.js` is no longer exported in https://cdnjs.com/libraries/swagger-ui 
there is only `swagger-ui-bundle.js`. I tested it locally after i remove `.min` then UI works.