### PR TITLE
fix: update urls types

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,10 +13,15 @@ export interface SwaggerOptions {
     | boolean
     | string[]
     | Record<string, unknown>
+    | Record<string, unknown>[]
     | null
     | undefined;
   dom_id?: string;
   url?: string;
+  urls?: {
+    url: string
+    name: string
+  }[];
   supportedSubmitMethods?: string[];
   docExpansion?: string;
   jsonEditor?: boolean;


### PR DESCRIPTION
`urls` works as intended in this plugin, but it currently requires typecasting.


As per https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/

`urls` is a supported parameter which is the following type:
> Array. An array of API definition objects ([{url: "<url1>", name: "<name1>"},{url: "<url2>", name: "<name2>"}])


Additionally, this PR clarifies and closes #153 