### PR TITLE
feat: add optional swaggerCdnUrl for KoaSwaggerUiOptions

### DIFF
--- a/lib/index.hbs
+++ b/lib/index.hbs
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>{{title}}</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/{{swaggerVersion}}/swagger-ui.min.css">
+  <link rel="stylesheet" href="{{swaggerCdnUrl}}/{{swaggerVersion}}/swagger-ui.min.css">
   <link rel="icon" type="image/png" href="{{favicon}}" />
   <style>
     html
@@ -70,8 +70,8 @@
 
 <div id="swagger-ui"></div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/{{swaggerVersion}}/swagger-ui-bundle.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/{{swaggerVersion}}/swagger-ui-standalone-preset.js"></script>
+<script src="{{swaggerCdnUrl}}/{{swaggerVersion}}/swagger-ui-bundle.js"></script>
+<script src="{{swaggerCdnUrl}}/{{swaggerVersion}}/swagger-ui-standalone-preset.js"></script>
 <script>
 function HideTopbarPlugin() {
   // this plugin overrides the Topbar component to return nothing

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -37,6 +37,7 @@ export interface KoaSwaggerUiOptions {
   oauthOptions: boolean | any;
   swaggerOptions: SwaggerOptions;
   swaggerVersion: string;
+  swaggerCdnUrl?: string;
   routePrefix: string | false;
   specPrefix: string;
   exposeSpec: boolean;
@@ -56,6 +57,7 @@ const defaultOptions: KoaSwaggerUiOptions = {
   routePrefix: '/docs',
   specPrefix: '/docs/spec',
   swaggerVersion: '',
+  swaggerCdnUrl: 'https://cdnjs.cloudflare.com/ajax/libs/swagger-ui',
   exposeSpec: false,
   hideTopbar: false,
   favicon: '/favicon.png',


### PR DESCRIPTION
When running this package in specific company network (with strict access control), it is required to use swagger static files with custom paths. This PR aims to solve the problem.